### PR TITLE
GeoJSON layer loading tweaks

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>DC Zoning Tools</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/components/ZoneAutocomplete.js
+++ b/client/src/components/ZoneAutocomplete.js
@@ -28,7 +28,7 @@ const ZoneAutocomplete = ({ zoneLabels, onZoneChange, map }) => {
   };
 
   return (
-    <div style={{ position: 'absolute', top: 10, left: 10, zIndex: 1000, width: '250px' }}>
+    <div style={{ position: 'absolute', top: 10, left: 50, zIndex: 1000, width: '250px' }}>
       <Select
         placeholder="Select a zoning label..."
         options={options}

--- a/client/src/components/ZoningMap.js
+++ b/client/src/components/ZoningMap.js
@@ -48,50 +48,45 @@ const ZoningMap = () => {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        {geoJsonData && (
-          <>
-            {showZoning && (
-              <ZoningGeoJSON
-                geoJsonData={geoJsonData}
-                selectedZone={selectedZone}
-                setSelectedZone={setSelectedZone}
-                zoningColors={zoningColors} // Pass the zoningColors object
-              />
-            )}
-             {showANC && ancData && (
-              <BoundariesGeoJSON
-                geoJsonData={ancData}
-                color="red" // Set the desired boundary color for ANC
-              />
-              )}
-              <BoundariesToggle
-                showBoundaries={showANC}
-                setShowBoundaries={setShowANC}
-                label="ANC"
-                style={{ top: '40px', right: '10px' }} // Set the desired position for the ANC toggle button
-              />
-              {showCompPlan && compPlanData && (
-              <BoundariesGeoJSON
-                geoJsonData={compPlanData}
-                color="blue" // Set the desired boundary color for Comp Plan
-              />
-               )}
-            <BoundariesToggle
-              showBoundaries={showCompPlan}
-              setShowBoundaries={setShowCompPlan}
-              label="Comp Plan"
-              style={{ top: '70px', right: '10px' }} // Set the desired position for the Comp Plan toggle button
-            />
-           
-            <ZoningToggle showZoning={showZoning} setShowZoning={setShowZoning} />
-            {/* Add the ANCToggle component */}
-            <ZoningToggle showZoning={showZoning} setShowZoning={setShowZoning} />
-            <ZoneAutocomplete
-              zoneLabels={zoneLabels} // <-- Pass the zoneLabels array
-              onZoneChange={(selectedZone) => setSelectedZone(selectedZone)}
-              map={map} // Pass the map instance to ZoneAutocomplete
-            />
-          </>
+        {showANC && ancData && (
+          <BoundariesGeoJSON
+            geoJsonData={ancData}
+            color="red" // Set the desired boundary color for ANC
+          />
+        )}
+        <BoundariesToggle
+          showBoundaries={showANC}
+          setShowBoundaries={setShowANC}
+          label="ANC"
+          style={{ top: '40px', right: '10px' }} // Set the desired position for the ANC toggle button
+        />
+        {showCompPlan && compPlanData && (
+          <BoundariesGeoJSON
+            geoJsonData={compPlanData}
+            color="blue" // Set the desired boundary color for Comp Plan
+          />
+        )}
+        <BoundariesToggle
+          showBoundaries={showCompPlan}
+          setShowBoundaries={setShowCompPlan}
+          label="Comp Plan"
+          style={{ top: '70px', right: '10px' }} // Set the desired position for the Comp Plan toggle button
+        />
+
+        <ZoningToggle showZoning={showZoning} setShowZoning={setShowZoning} />
+        {/* Add the ANCToggle component */}
+        <ZoneAutocomplete
+          zoneLabels={zoneLabels} // <-- Pass the zoneLabels array
+          onZoneChange={(selectedZone) => setSelectedZone(selectedZone)}
+          map={map} // Pass the map instance to ZoneAutocomplete
+        />
+        {showZoning && geoJsonData && (
+          <ZoningGeoJSON
+            geoJsonData={geoJsonData}
+            selectedZone={selectedZone}
+            setSelectedZone={setSelectedZone}
+            zoningColors={zoningColors} // Pass the zoningColors object
+          />
         )}
       </MapContainer>
     </div>


### PR DESCRIPTION
The issue where ANC boundaries (or zoning data) needed to be disabled or toggled before the GeoJSON layer became interactive smacked of a race condition somewhere between the app, React Leaflet, and Leaflet.js. By not re-rendering all child components when the GeoJSON data loads, and by moving the layer last in the rendering, we're able to avoid the set of conditions that lead to it.

This PR also:

* Moves the zoning autocomplete a smidge to the right to have it not overlap the zoom control
* Sets a page title
* Removes a duplicate `ZoningToggle`

Fixes #1 