### PR TITLE
Allow mousewheel zooming on the map

### DIFF
--- a/client/src/components/ZoningMap.js
+++ b/client/src/components/ZoningMap.js
@@ -1,5 +1,5 @@
 // ZoningMap.js
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { MapContainer, TileLayer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { fetchGeoJsonData } from '../utils/fetchGeoJSONData';
@@ -14,7 +14,7 @@ const ZoningMap = () => {
   const [geoJsonData, setGeoJsonData] = useState(null);
   const [showZoning, setShowZoning] = useState(true);
   const [selectedZone, setSelectedZone] = useState(null);
-  const [map, setMap] = useState(null); // Add a new state for the map instance
+  const mapRef = useRef(null); // Hold the map instance for programmatic access in other components
   const zoneLabels = Object.keys(zoningColors); // <-- Get the zone labels from the zoningColors object
   const [showANC, setShowANC] = useState(true); // Add a new state for showing or hiding ANC boundaries
   const [ancData, setAncData] = useState(null); // Add a new state for ANC GeoJSON data
@@ -41,11 +41,6 @@ const ZoningMap = () => {
     setStateFunction(data);
   };
 
-  const handleMapCreated = (mapInstance) => {
-    // Perform any other actions with the map instance here
-    setMap(mapInstance);  // Assuming you have a state setter for map
-  };
-
   useEffect(() => {
     fetchDataAndUpdateState('/datasets/simplified_zoning_map.geojson', setGeoJsonData);
     fetchDataAndUpdateState(
@@ -59,13 +54,7 @@ const ZoningMap = () => {
 
   return (
     <div style={{ position: 'relative', height: '100vh' }}>
-      <MapContainer
-        center={[38.9, -77.02]}
-        zoom={13}
-        scrollWheelZoom={false}
-        style={{ height: '100%' }}
-        whenCreated={handleMapCreated} // Add the whenCreated prop to set the map instance
-      >
+      <MapContainer center={[38.9, -77.02]} zoom={13} style={{ height: '100%' }} ref={mapRef}>
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -101,7 +90,7 @@ const ZoningMap = () => {
         <ZoneAutocomplete
           zoneLabels={zoneLabels} // <-- Pass the zoneLabels array
           onZoneChange={(selectedZone) => setSelectedZone(selectedZone)}
-          map={map} // Pass the map instance to ZoneAutocomplete
+          map={mapRef.current} // Pass the map instance to ZoneAutocomplete
         />
         <div
           style={{


### PR DESCRIPTION
This uses refs (instead of state) to track the instantiated map so we can programatically disable the default scroll and click+drag behavior in various child components (such as the the ZoneAutocomplete).

idk why react-leaflet exposes this handler. Using refs is more canonical React.

Touches #2